### PR TITLE
Issue From Upstream (271) enable copy

### DIFF
--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -45,6 +45,16 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
+      label: "Edit",
+      submenu: [
+        {
+          label: "Copy",
+          accelerator: "Command+C",
+          selector: "copy:"
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -45,12 +45,12 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
-      label: "Edit",
+      label: 'Edit',
       submenu: [
         {
-          label: "Copy",
-          accelerator: "Command+C",
-          selector: "copy:"
+          label: 'Copy',
+          accelerator: 'Command+C',
+          selector: 'copy:'
         }
       ]
     },

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -18,6 +18,16 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
+      label: "Edit",
+      submenu: [
+        {
+          label: "Copy",
+          accelerator: "Ctrl+C",
+          selector: "copy:"
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -18,12 +18,12 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
-      label: "Edit",
+      label: 'Edit',
       submenu: [
         {
-          label: "Copy",
-          accelerator: "Ctrl+C",
-          selector: "copy:"
+          label: 'Copy',
+          accelerator: 'Ctrl+C',
+          selector: 'copy:'
         }
       ]
     },


### PR DESCRIPTION
Following the guide provided in issue #271: https://pracucci.com/atom-electron-enable-copy-and-paste.html
implemented copy text functionality.